### PR TITLE
Update example project's Docker setup

### DIFF
--- a/example_project/README.md
+++ b/example_project/README.md
@@ -43,7 +43,19 @@ Build and run the container.
 
 ```bash
 $ docker build -t django-oidc-provider .
-$ docker run -d -p 8000:8000 django-oidc-provider
+$ docker run --name django-oidc-provider -d -p 8000:8000 django-oidc-provider
+```
+
+If you're using Docker Toolbox (docker-machine), you'll need to set via environment variable the `SITE_URL` setting so it uses the VM's IP address.
+
+```bash
+$ docker run --name django-oidc-provider -d -p 8000:8000 -e "SITE_URL=http://`docker-machine ip`:8000" django-oidc-provider 
+```
+
+Create your super user.
+
+```bash
+$ docker exec -it django-oidc-provider python manage.py createsuperuser
 ```
 
 ## Install package for development

--- a/example_project/myapp/settings.py
+++ b/example_project/myapp/settings.py
@@ -87,5 +87,5 @@ LOGIN_REDIRECT_URL = '/'
 
 # OIDC Provider settings
 
-SITE_URL = 'http://localhost:8000'
+SITE_URL = os.environ.get('SITE_URL', 'http://localhost:8000')
 OIDC_SESSION_MANAGEMENT_ENABLE = True


### PR DESCRIPTION
This PR introduces support to set the example project's `SITE_URL` Django setting via a Docker environment, which is useful for when running Docker via docker-machine.